### PR TITLE
Support converting large dates (i.e. +10999-12-31) from string to Date32

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -4217,6 +4217,23 @@ mod tests {
     }
 
     #[test]
+    fn test_cast_string_with_large_date_to_date32() {
+        let array = Arc::new(StringArray::from(vec![
+            Some("+10999-12-31"),
+            Some("-0010-02-28")
+        ])) as ArrayRef;
+        let to_type = DataType::Date32;
+        let options = CastOptions {
+            safe: false,
+            format_options: FormatOptions::default(),
+        };
+        let b = cast_with_options(&array, &to_type, &options).unwrap();
+        let c = b.as_primitive::<Date32Type>();
+        assert_eq!(3298139, c.value(0));
+        assert_eq!(-723122, c.value(1));
+    }
+
+    #[test]
     fn test_cast_string_format_yyyymmdd_to_date32() {
         let a0 = Arc::new(StringViewArray::from(vec![
             Some("2020-12-25"),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -4220,7 +4220,7 @@ mod tests {
     fn test_cast_string_with_large_date_to_date32() {
         let array = Arc::new(StringArray::from(vec![
             Some("+10999-12-31"),
-            Some("-0010-02-28")
+            Some("-0010-02-28"),
         ])) as ArrayRef;
         let to_type = DataType::Date32;
         let options = CastOptions {

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -591,6 +591,26 @@ const EPOCH_DAYS_FROM_CE: i32 = 719_163;
 const ERR_NANOSECONDS_NOT_SUPPORTED: &str = "The dates that can be represented as nanoseconds have to be between 1677-09-21T00:12:44.0 and 2262-04-11T23:47:16.854775804";
 
 fn parse_date(string: &str) -> Option<NaiveDate> {
+    // If the date has an extended (signed) year such as "+10999-12-31" or "-0012-05-06"
+    if string.starts_with('+') || string.starts_with('-') {
+        // Skip the sign and look for the hyphen that terminates the year digits.
+        // According to ISO 8601 the unsigned part must be at least 4 digits.
+        let rest = &string[1..];
+        let hyphen = rest.find('-')?;
+        if hyphen < 4 {
+            return None;
+        }
+        // The year substring is the sign and the digits (but not the separator)
+        // e.g. for "+10999-12-31", hyphen is 5 and s[..6] is "+10999"
+        let year: i32 = string[..hyphen + 1].parse().ok()?;
+        // The remainder should begin with a '-' which we strip off, leaving the month-day part.
+        let remainder = string[hyphen + 1..].strip_prefix('-')?;
+        let mut parts = remainder.splitn(2, '-');
+        let month: u32 = parts.next()?.parse().ok()?;
+        let day: u32 = parts.next()?.parse().ok()?;
+        return NaiveDate::from_ymd_opt(year, month, day);
+    }
+
     if string.len() > 10 {
         // Try to parse as datetime and return just the date part
         return string_to_datetime(&Utc, string)


### PR DESCRIPTION
# Which issue does this PR close?

Closes apache/arrow-rs-object-store#22

# Rationale for this change
 
Support for casting large dates from string to Date32.

# What changes are included in this PR?

Extend the `parse_date` method, which is used in the `impl Parser for Date32Type`, to handle dates which are prefixed with `+` or `-`. If the date is not prefixed with `+` or `-`, the existing logic is used unmodified.

This code isn't as optimized as the code for processing more common date formats - but given that these extended dates are relatively rare in practice, I don't think it matters all that much.

# Are there any user-facing changes?

Aside from the desired fix, no.
