### PR TITLE
fix: Support specifying the full object meta in ParquetObjectReader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,6 @@ simdutf8 = { version = "0.1.5", default-features = false }
 inherits = "release"
 debug = true
 strip = false
+
+[patch.crates-io]
+object_store = { git = "https://github.com/apache/arrow-rs-object-store", rev = "f0a772cd49d2ebb1f19f487ccd93d705f48dc891" }

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -29,12 +29,19 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
 # See https://github.com/briansmith/ring/issues/918#issuecomment-2077788925
-ring = { version = "0.17", default-features = false, features = ["wasm32_unknown_unknown_js", "std"], optional = true }
+ring = { version = "0.17", default-features = false, features = [
+    "wasm32_unknown_unknown_js",
+    "std",
+], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "runtime-rng",
+] }
 
 [dependencies]
 arrow-array = { workspace = true, optional = true }
@@ -45,59 +52,132 @@ arrow-data = { workspace = true, optional = true }
 arrow-schema = { workspace = true, optional = true }
 arrow-select = { workspace = true, optional = true }
 arrow-ipc = { workspace = true, optional = true }
-object_store = { version = "0.12.0", default-features = false, optional = true }
+object_store = { version = "0.12.4", default-features = false, optional = true }
 
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
-brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
+brotli = { version = "8.0", default-features = false, features = [
+    "std",
+], optional = true }
 # To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-rust_backened` backends
 flate2 = { version = "1.1", default-features = false, optional = true }
-lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"], optional = true }
+lz4_flex = { version = "0.11", default-features = false, features = [
+    "std",
+    "frame",
+], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
 chrono = { workspace = true }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false }
-base64 = { version = "0.22", default-features = false, features = ["std", ], optional = true }
-clap = { version = "4.1", default-features = false, features = ["std", "derive", "env", "help", "error-context", "usage"], optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
-serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
+base64 = { version = "0.22", default-features = false, features = [
+    "std",
+], optional = true }
+clap = { version = "4.1", default-features = false, features = [
+    "std",
+    "derive",
+    "env",
+    "help",
+    "error-context",
+    "usage",
+], optional = true }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+], optional = true }
+serde_json = { version = "1.0", default-features = false, features = [
+    "std",
+], optional = true }
 seq-macro = { version = "0.3", default-features = false }
-futures = { version = "0.3", default-features = false, features = ["std"], optional = true }
-tokio = { version = "1.0", optional = true, default-features = false, features = ["macros", "rt", "io-util"] }
+futures = { version = "0.3", default-features = false, features = [
+    "std",
+], optional = true }
+tokio = { version = "1.0", optional = true, default-features = false, features = [
+    "macros",
+    "rt",
+    "io-util",
+] }
 hashbrown = { version = "0.15", default-features = false }
-twox-hash = { version = "2.0", default-features = false, features = ["xxhash64"] }
+twox-hash = { version = "2.0", default-features = false, features = [
+    "xxhash64",
+] }
 paste = { version = "1.0" }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 crc32fast = { version = "1.4.2", optional = true, default-features = false }
-simdutf8 = { workspace = true , optional = true }
-ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
+simdutf8 = { workspace = true, optional = true }
+ring = { version = "0.17", default-features = false, features = [
+    "std",
+], optional = true }
 
 [dev-dependencies]
 base64 = { version = "0.22", default-features = false, features = ["std"] }
-criterion = { version = "0.5", default-features = false, features = ["async_futures"]  }
+criterion = { version = "0.5", default-features = false, features = [
+    "async_futures",
+] }
 snap = { version = "1.0", default-features = false }
 tempfile = { version = "3.0", default-features = false }
 brotli = { version = "8.0", default-features = false, features = ["std"] }
-flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
-lz4_flex = { version = "0.11", default-features = false, features = ["std", "frame"] }
+flate2 = { version = "1.0", default-features = false, features = [
+    "rust_backend",
+] }
+lz4_flex = { version = "0.11", default-features = false, features = [
+    "std",
+    "frame",
+] }
 zstd = { version = "0.13", default-features = false }
 serde_json = { version = "1.0", features = ["std"], default-features = false }
-arrow = { workspace = true, features = ["ipc", "test_utils", "prettyprint", "json"] }
-tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "io-util", "fs"] }
-rand = { version = "0.9", default-features = false, features = ["std", "std_rng", "thread_rng"] }
-object_store = { version = "0.12.0", default-features = false, features = ["azure", "fs"] }
-sysinfo = { version = "0.36.0", default-features = false, features = ["system"] }
+arrow = { workspace = true, features = [
+    "ipc",
+    "test_utils",
+    "prettyprint",
+    "json",
+] }
+tokio = { version = "1.0", default-features = false, features = [
+    "macros",
+    "rt-multi-thread",
+    "io-util",
+    "fs",
+] }
+rand = { version = "0.9", default-features = false, features = [
+    "std",
+    "std_rng",
+    "thread_rng",
+] }
+object_store = { version = "0.12.4", default-features = false, features = [
+    "azure",
+    "fs",
+] }
+sysinfo = { version = "0.36.0", default-features = false, features = [
+    "system",
+] }
 
 [package.metadata.docs.rs]
 all-features = true
 
 [features]
-default = ["arrow", "snap", "brotli", "flate2-zlib-rs", "lz4", "zstd", "base64", "simdutf8"]
+default = [
+    "arrow",
+    "object_store",
+    "snap",
+    "brotli",
+    "flate2-zlib-rs",
+    "lz4",
+    "zstd",
+    "base64",
+    "simdutf8",
+]
 # Enable lz4
 lz4 = ["lz4_flex"]
 # Enable arrow reader/writer APIs
-arrow = ["base64", "arrow-array", "arrow-buffer", "arrow-cast", "arrow-data", "arrow-schema", "arrow-select", "arrow-ipc"]
+arrow = [
+    "base64",
+    "arrow-array",
+    "arrow-buffer",
+    "arrow-cast",
+    "arrow-data",
+    "arrow-schema",
+    "arrow-select",
+    "arrow-ipc",
+]
 # Enable support for arrow canonical extension types
 arrow_canonical_extension_types = ["arrow-schema?/canonical_extension_types"]
 # Enable CLI tools

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -86,9 +86,12 @@ impl ParquetObjectReader {
     }
 
     /// Set the object versioning type to use when retrieving objects from the object store.
-    pub fn with_object_versioning_type(self, object_versioning_type: ObjectVersionType) -> Self {
+    pub fn with_object_versioning_type(
+        self,
+        object_versioning_type: Option<ObjectVersionType>,
+    ) -> Self {
         Self {
-            object_versioning_type: Arc::new(Some(object_versioning_type)),
+            object_versioning_type: Arc::new(object_versioning_type),
             ..self
         }
     }

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -238,6 +238,7 @@ impl AsyncFileReader for ParquetObjectReader {
         options: Option<&'a ArrowReaderOptions>,
     ) -> BoxFuture<'a, Result<Arc<ParquetMetaData>>> {
         Box::pin(async move {
+            #[allow(unused_mut)] // mut is used in the feature
             let mut metadata = ParquetMetaDataReader::new()
                 .with_column_indexes(self.preload_column_index)
                 .with_offset_indexes(self.preload_offset_index)

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -23,9 +23,18 @@ use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt, TryFutureExt};
-use object_store::{path::Path, ObjectStore};
-use object_store::{GetOptions, GetRange};
+use object_store::ObjectStore;
+use object_store::{GetOptions, GetRange, ObjectMeta};
 use tokio::runtime::Handle;
+
+/// Indicates the type of object versioning to use when retrieving objects from the object store.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ObjectVersionType {
+    /// Uses the ETag property of the object to retrieve the specific object
+    ETag,
+    /// Uses the Version property of the object to retrieve the specific object
+    Version,
+}
 
 /// Reads Parquet files in object storage using [`ObjectStore`].
 ///
@@ -46,7 +55,7 @@ use tokio::runtime::Handle;
 /// println!("Found Blob with {}B at {}", meta.size, meta.location);
 ///
 /// // Show Parquet metadata
-/// let reader = ParquetObjectReader::new(storage_container, meta.location).with_file_size(meta.size);
+/// let reader = ParquetObjectReader::new(storage_container, meta);
 /// let builder = ParquetRecordBatchStreamBuilder::new(reader).await.unwrap();
 /// print_parquet_metadata(&mut stdout(), builder.metadata());
 /// # }
@@ -54,25 +63,33 @@ use tokio::runtime::Handle;
 #[derive(Clone, Debug)]
 pub struct ParquetObjectReader {
     store: Arc<dyn ObjectStore>,
-    path: Path,
-    file_size: Option<u64>,
+    object_meta: ObjectMeta,
     metadata_size_hint: Option<usize>,
     preload_column_index: bool,
     preload_offset_index: bool,
+    object_versioning_type: Arc<Option<ObjectVersionType>>,
     runtime: Option<Handle>,
 }
 
 impl ParquetObjectReader {
     /// Creates a new [`ParquetObjectReader`] for the provided [`ObjectStore`] and [`Path`].
-    pub fn new(store: Arc<dyn ObjectStore>, path: Path) -> Self {
+    pub fn new(store: Arc<dyn ObjectStore>, object_meta: ObjectMeta) -> Self {
         Self {
             store,
-            path,
-            file_size: None,
+            object_meta,
             metadata_size_hint: None,
             preload_column_index: false,
             preload_offset_index: false,
             runtime: None,
+            object_versioning_type: Arc::new(None),
+        }
+    }
+
+    /// Set the object versioning type to use when retrieving objects from the object store.
+    pub fn with_object_versioning_type(self, object_versioning_type: ObjectVersionType) -> Self {
+        Self {
+            object_versioning_type: Arc::new(Some(object_versioning_type)),
+            ..self
         }
     }
 
@@ -81,22 +98,6 @@ impl ParquetObjectReader {
     pub fn with_footer_size_hint(self, hint: usize) -> Self {
         Self {
             metadata_size_hint: Some(hint),
-            ..self
-        }
-    }
-
-    /// Provide the byte size of this file.
-    ///
-    /// If provided, the file size will ensure that only bounded range requests are used. If file
-    /// size is not provided, the reader will use suffix range requests to fetch the metadata.
-    ///
-    /// Providing this size up front is an important optimization to avoid extra calls when the
-    /// underlying store does not support suffix range requests.
-    ///
-    /// The file size can be obtained using [`ObjectStore::list`] or [`ObjectStore::head`].
-    pub fn with_file_size(self, file_size: u64) -> Self {
-        Self {
-            file_size: Some(file_size),
             ..self
         }
     }
@@ -134,7 +135,7 @@ impl ParquetObjectReader {
 
     fn spawn<F, O, E>(&self, f: F) -> BoxFuture<'_, Result<O>>
     where
-        F: for<'a> FnOnce(&'a Arc<dyn ObjectStore>, &'a Path) -> BoxFuture<'a, Result<O, E>>
+        F: for<'a> FnOnce(&'a Arc<dyn ObjectStore>, &'a ObjectMeta) -> BoxFuture<'a, Result<O, E>>
             + Send
             + 'static,
         O: Send + 'static,
@@ -142,10 +143,10 @@ impl ParquetObjectReader {
     {
         match &self.runtime {
             Some(handle) => {
-                let path = self.path.clone();
+                let object_meta = self.object_meta.clone();
                 let store = Arc::clone(&self.store);
                 handle
-                    .spawn(async move { f(&store, &path).await })
+                    .spawn(async move { f(&store, &object_meta).await })
                     .map_ok_or_else(
                         |e| match e.try_into_panic() {
                             Err(e) => Err(ParquetError::External(Box::new(e))),
@@ -155,7 +156,9 @@ impl ParquetObjectReader {
                     )
                     .boxed()
             }
-            None => f(&self.store, &self.path).map_err(|e| e.into()).boxed(),
+            None => f(&self.store, &self.object_meta)
+                .map_err(|e| e.into())
+                .boxed(),
         }
     }
 }
@@ -166,9 +169,9 @@ impl MetadataSuffixFetch for &mut ParquetObjectReader {
             range: Some(GetRange::Suffix(suffix as u64)),
             ..Default::default()
         };
-        self.spawn(|store, path| {
+        self.spawn(|store, meta| {
             async move {
-                let resp = store.get_opts(path, options).await?;
+                let resp = store.get_opts(&meta.location, options).await?;
                 Ok::<_, ParquetError>(resp.bytes().await?)
             }
             .boxed()
@@ -178,14 +181,23 @@ impl MetadataSuffixFetch for &mut ParquetObjectReader {
 
 impl AsyncFileReader for ParquetObjectReader {
     fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
-        self.spawn(|store, path| store.get_range(path, range))
-    }
+        let object_versioning_type = Arc::clone(&self.object_versioning_type);
+        self.spawn(move |store, meta| {
+            if let Some(object_versioning_type) = object_versioning_type.as_ref() {
+                let opts = GetOptions::default().with_range(Some(range));
+                let opts = match object_versioning_type {
+                    ObjectVersionType::ETag => opts.with_if_match(meta.e_tag.as_deref()),
+                    ObjectVersionType::Version => opts.with_version(meta.version.as_deref()),
+                };
 
-    fn get_byte_ranges(&mut self, ranges: Vec<Range<u64>>) -> BoxFuture<'_, Result<Vec<Bytes>>>
-    where
-        Self: Send,
-    {
-        self.spawn(|store, path| async move { store.get_ranges(path, &ranges).await }.boxed())
+                store
+                    .get_opts(&meta.location, opts)
+                    .and_then(|resp| resp.bytes())
+                    .boxed()
+            } else {
+                store.get_range(&meta.location, range)
+            }
+        })
     }
 
     // This method doesn't directly call `self.spawn` because all of the IO that is done down the
@@ -210,11 +222,8 @@ impl AsyncFileReader for ParquetObjectReader {
                     .with_decryption_properties(options.file_decryption_properties.as_ref());
             }
 
-            let metadata = if let Some(file_size) = self.file_size {
-                metadata.load_and_finish(self, file_size).await?
-            } else {
-                metadata.load_via_suffix_and_finish(self).await?
-            };
+            let file_size = self.object_meta.size;
+            let metadata = metadata.load_and_finish(self, file_size).await?;
 
             Ok(Arc::new(metadata))
         })
@@ -254,8 +263,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple() {
         let (meta, store) = get_meta_store().await;
-        let object_reader =
-            ParquetObjectReader::new(store, meta.location).with_file_size(meta.size);
+        let object_reader = ParquetObjectReader::new(store, meta);
 
         let builder = ParquetRecordBatchStreamBuilder::new(object_reader)
             .await
@@ -269,7 +277,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple_without_file_length() {
         let (meta, store) = get_meta_store().await;
-        let object_reader = ParquetObjectReader::new(store, meta.location);
+        let object_reader = ParquetObjectReader::new(store, meta);
 
         let builder = ParquetRecordBatchStreamBuilder::new(object_reader)
             .await
@@ -285,8 +293,7 @@ mod tests {
         let (mut meta, store) = get_meta_store().await;
         meta.location = Path::from("I don't exist.parquet");
 
-        let object_reader =
-            ParquetObjectReader::new(store, meta.location).with_file_size(meta.size);
+        let object_reader = ParquetObjectReader::new(store, meta);
         // Cannot use unwrap_err as ParquetRecordBatchStreamBuilder: !Debug
         match ParquetRecordBatchStreamBuilder::new(object_reader).await {
             Ok(_) => panic!("expected failure"),
@@ -319,9 +326,7 @@ mod tests {
 
         let initial_actions = num_actions.load(Ordering::Relaxed);
 
-        let reader = ParquetObjectReader::new(store, meta.location)
-            .with_file_size(meta.size)
-            .with_runtime(rt.handle().clone());
+        let reader = ParquetObjectReader::new(store, meta).with_runtime(rt.handle().clone());
 
         let builder = ParquetRecordBatchStreamBuilder::new(reader).await.unwrap();
         let batches: Vec<_> = builder.build().unwrap().try_collect().await.unwrap();
@@ -347,9 +352,7 @@ mod tests {
 
         let (meta, store) = get_meta_store().await;
 
-        let reader = ParquetObjectReader::new(store, meta.location)
-            .with_file_size(meta.size)
-            .with_runtime(rt.handle().clone());
+        let reader = ParquetObjectReader::new(store, meta).with_runtime(rt.handle().clone());
 
         let current_id = std::thread::current().id();
 
@@ -372,9 +375,7 @@ mod tests {
 
         let (meta, store) = get_meta_store().await;
 
-        let mut reader = ParquetObjectReader::new(store, meta.location)
-            .with_file_size(meta.size)
-            .with_runtime(rt.handle().clone());
+        let mut reader = ParquetObjectReader::new(store, meta).with_runtime(rt.handle().clone());
 
         rt.shutdown_background();
 


### PR DESCRIPTION
* Supports specifying the full object meta in `ParquetObjectReader`. This replaces calls to `with_file_size`, as the file size is contained within the meta.
* Adds support for `ObjectVersionType`, which when specified updates the object store calls to use `GetOptions` with the specified ETag or Version matcher.