### PR TITLE
fix: Use object_meta.size in new_with_meta to avoid suffix requests

### DIFF
--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -96,10 +96,11 @@ impl ParquetObjectReader {
     }
 
     pub fn new_with_meta(store: Arc<dyn ObjectStore>, object_meta: ObjectMeta) -> Self {
+        let file_size = object_meta.size;
         Self {
             store,
+            file_size: Some(file_size),
             object_meta,
-            file_size: None,
             metadata_size_hint: None,
             preload_column_index: false,
             preload_offset_index: false,

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -99,8 +99,8 @@ impl ParquetObjectReader {
         let file_size = object_meta.size;
         Self {
             store,
-            file_size: Some(file_size),
             object_meta,
+            file_size: Some(file_size),
             metadata_size_hint: None,
             preload_column_index: false,
             preload_offset_index: false,


### PR DESCRIPTION
When ObjectMeta is provided to new_with_meta(), we already have the file size available. Setting file_size to Some(object_meta.size) ensures that get_metadata() uses bounded range requests instead of suffix requests.

This fixes compatibility with Azure Blob Storage which does not support HTTP Range header with suffix format (bytes=-N), causing the error: 'Azure does not support suffix range requests'

Previously, callers had to explicitly chain .with_file_size(meta.size) after new_with_meta(), which was easy to forget and caused issues.
